### PR TITLE
Configuratie H2

### DIFF
--- a/src/Starter/src/main/resources/application.properties
+++ b/src/Starter/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 ## H2 Embedded (develop environment)
 server.port=6789
 spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.url=jdbc:h2:./test-db;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.url=jdbc:h2:./test-db;DB_CLOSE_ON_EXIT=FALSE;MV_STORE=FALSE;MVCC=FALSE;FILE_LOCK=NO
 spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Het probleem dat Intelli je database niet kon openen kwam omdat de H2 database standaard gebruikt maakt van het nieuwe `MV_STORE`, met deze configuratie is dat uit te stellen. Ik heb ook `FILE_LOCK` uitgeschakeld zodat je de database kan openen tegelijk met de embedded server.
