### PR TITLE
Improve error message when access token is invalid

### DIFF
--- a/src/PcsAuth/src/main/java/com/projectb/controller/SignInController.java
+++ b/src/PcsAuth/src/main/java/com/projectb/controller/SignInController.java
@@ -59,7 +59,7 @@ public class SignInController {
         DebugToken debugToken = facebookAppTemplate.fetchObject("debug_token", DebugToken.class, map);
         DebugData debugData = debugToken.getData();
 
-        if(!debugData.getAppId().equals(environment.getProperty("facebook.clientId")))
+        if(debugData.getAppId() == null || !debugData.getAppId().equals(environment.getProperty("facebook.clientId")))
             throw new InvalidFacebookCredentials();
         if(!debugData.isValid())
             throw new InvalidFacebookCredentials();


### PR DESCRIPTION
### lage prioriteit

If-check uitgebreid bij inloggen Facebook om een iets duidelijke foutmelding te geven als de Facebook access token ongeldig is. Hij gooit nu een `InvalidFacebookCredentials` ipv een `NullPointerException`.
