### PR TITLE
Add @NotNull to user lat and lng

### DIFF
--- a/src/Domain/src/main/java/com/projectb/entities/User.java
+++ b/src/Domain/src/main/java/com/projectb/entities/User.java
@@ -64,9 +64,11 @@ public class User extends AbsEntity implements Serializable {
     @Setter
     private boolean enabled;
 
+    @NotNull
     @Setter
     private Double latitude;
 
+    @NotNull
     @Setter
     private Double longitude;
 }

--- a/src/PcsAuth/src/main/java/com/projectb/config/WebSecurityConfig.java
+++ b/src/PcsAuth/src/main/java/com/projectb/config/WebSecurityConfig.java
@@ -65,6 +65,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         user.setPassword("password");
         user.setName("Sara Tancredi");
         user.setSummary("Lorum ipsum dolor sit amet.");
+        user.setLongitude(51.441642);
+        user.setLatitude(5.469722);
 
         signUpService().signUp(user);
     }


### PR DESCRIPTION
De `already built` error was een gevolg van een validation error. Er wordt in de `WebSecurityConfig` ook nog een standaard user aangemaakt, die had nog geen lat/lng. Nu built hij wel bij mij zonder `already built` fout.
