### PR TITLE
Also set image url when logging in from the web

### DIFF
--- a/src/BsAuth/src/main/java/com/projectb/auth/BasicSignInService.java
+++ b/src/BsAuth/src/main/java/com/projectb/auth/BasicSignInService.java
@@ -34,12 +34,4 @@ public class BasicSignInService implements SignInService {
 
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), authorities));
     }
-
-    @Override
-    public void signInSocial(@NonNull String username, @NonNull String imageUrl) {
-        User user = userRepo.findByUsername(username);
-        user.setImageUrl(imageUrl);
-        userRepo.save(user);
-        signIn(username);
-    }
 }

--- a/src/BsAuth/src/main/java/com/projectb/auth/SignInService.java
+++ b/src/BsAuth/src/main/java/com/projectb/auth/SignInService.java
@@ -2,6 +2,4 @@ package com.projectb.auth;
 
 public interface SignInService {
     void signIn(String username);
-
-    void signInSocial(String username, String imageUrl);
 }

--- a/src/PcsAuth/src/main/java/com/projectb/auth/UserConnectionSignUp.java
+++ b/src/PcsAuth/src/main/java/com/projectb/auth/UserConnectionSignUp.java
@@ -23,6 +23,7 @@ public class UserConnectionSignUp implements ConnectionSignUp {
             user.setUsername(profile.getEmail());
             user.setPassword("generate"); // TODO: Generate a password, or better yet. Or disable local login.
             user.setName(profile.getName());
+            user.setImageUrl(connection.getImageUrl());
 
             signUpService.signUp(user);
 

--- a/src/PcsAuth/src/main/java/com/projectb/controller/SignInController.java
+++ b/src/PcsAuth/src/main/java/com/projectb/controller/SignInController.java
@@ -93,7 +93,7 @@ public class SignInController {
             connectionSignUp.execute(connection);
 
         // sign in
-        signInService.signInSocial(userIdsWithConnection.get(0), connectionData.getImageUrl());
+        signInService.signIn(userIdsWithConnection.get(0));
 
         return "redirect:/";
     }


### PR DESCRIPTION
Ik heb de code om de `imageUrl` te zetten in `UserConnectionSignUp` gezet. Deze word aangeroepen voor iedereen die via social media aanmeld.

Dit lost het probleem op dat als je via de website via Facebook inlogt de `imageUrl` niet gezet wordt.

Als je deze goed vind, heb je toestemming om PR #57 ook te mergen.
